### PR TITLE
Update getAboveThreshold.bash

### DIFF
--- a/getAboveThreshold.bash
+++ b/getAboveThreshold.bash
@@ -6,8 +6,8 @@ cutoff=$3
 out=$4
 thread=$5
 
-module load samtools
-module load bedtools2
+#module load samtools
+#module load bedtools2
 
 samtools view -hb $inputFile $chr -@ $thread | bedtools genomecov -ibam - -pc -bga | grep -w "^$chr" | awk -v c=$cutoff '{if($4 > c){print}}' > $out
 


### PR DESCRIPTION
Prevents a warning from appearing on personal computers and other systems that do not use environment modules. On systems that do use environment variables, going by the example in READE.md, the modules should already be loaded before calling this script, so that is not an issue.