### PR TITLE
 Update getCountFiles.R 

### DIFF
--- a/getCountFiles.R
+++ b/getCountFiles.R
@@ -34,8 +34,8 @@ getSegments <- function(s) {
   	colnames(sub1) <- c("chr", "start", "end")
   
   	if (nrow(sub1) > 1) {
-    		sub1.sort   <- bedr.sort.region(sub1)
-    		sub1.merge <- bedr.merge.region(sub1.sort, distance = inputLength, verbose = T)
+    		sub1.sort   <- bedr.sort.region(sub1, check.chr = FALSE)
+    		sub1.merge <- bedr.merge.region(sub1.sort, distance = inputLength, verbose = T, check.chr = FALSE)
     		sub1.merge$mid <- round((sub1.merge$end - sub1.merge$start)/2) + sub1.merge$start
     		sub1.merge$start <- sub1.merge$mid - inputLength/2
     		sub1.merge$end <- sub1.merge$mid + inputLength/2

--- a/getCountFiles.R
+++ b/getCountFiles.R
@@ -82,7 +82,7 @@ registerDoParallel(cl)
 new <- data.frame(matrix(ncol = 4))
 colnames(new) <- c("chr", "start", "end", "name")
 
-result <- foreach(i=unique(file$name)) %dopar% getSegments(i)
+result <- foreach(i=unique(file$name)) %dopar% {getSegments(i)}
 #save(result, file=args[3])
 
 for (i in 1:length(result)) {


### PR DESCRIPTION
The bedr library assumes that chromosomes are labeled chr12, chrX, chrMT, etc.; rather than by accession number (such as chrNC_007112.7). In my experience, the chromosomes passed to this script are labeled by accession number, and so check.chr must be set to false.

Also, for whatever reason, excluding the braces on line 85 causes the program to fail completely and utterly on my machine. I have no idea why this is the case, but the problem is reproducible.