### PR TITLE
Fix preprocessing

### DIFF
--- a/getCountFiles.R
+++ b/getCountFiles.R
@@ -89,7 +89,7 @@ for (i in 1:length(result)) {
         new <- rbind(new, result[[i]])
 }
 new <- new[!is.na(new$chr),]
-write.table(format(new, scientific = FALSE), file=args[3], quote = F, sep = "\t", row.names = F)
+write.table(format(new, scientific = FALSE, trim = TRUE), file=args[3], quote = F, sep = "\t", row.names = F)
 } else {
 print("Input has 0 line.")
 }

--- a/getCountFiles.R
+++ b/getCountFiles.R
@@ -89,7 +89,7 @@ for (i in 1:length(result)) {
         new <- rbind(new, result[[i]])
 }
 new <- new[!is.na(new$chr),]
-write.table(new, file=args[3], quote = F, sep = "\t", row.names = F)
+write.table(format(new, scientific = FALSE), file=args[3], quote = F, sep = "\t", row.names = F)
 } else {
 print("Input has 0 line.")
 }


### PR DESCRIPTION
This fixes multiple issues with the preprocessor, some of which can lead to very confusing errors when running run_rcl.sh. The issues fixed are:
- For small input lengths (~100 bp), some lines in regions.txt could be duplicated.
- Some lines in regions.txt could have negative start positions
- Some lines in regions.txt could have end positions greater than the length of the chromosome
- Some lines in regioins.txt could have their start or end positions be printed in scientific notation